### PR TITLE
fix: webwallet logout

### DIFF
--- a/src/components/web/WebWalletLogin.vue
+++ b/src/components/web/WebWalletLogin.vue
@@ -18,7 +18,12 @@ export default {
         }
     },
     mounted() {
-        this.$erd.webWallet.callbackReceived(window.location.search);
+        // returns true if callback handled a login
+        if (this.$erd.webWallet.callbackReceived(window.location.search)) {
+            // fix: logout from first attempt, otherwise 2 logouts are required
+            // remove URL GET parameters
+            window.history.pushState({}, document.title, window.location.pathname);
+        }
     },
     methods: {
         login (name) {

--- a/src/providers/web/WebWalletStrategy.ts
+++ b/src/providers/web/WebWalletStrategy.ts
@@ -46,6 +46,7 @@ class WebWalletProviderStrategy implements IProviderStrategy {
         } else {
             this._lastStatus = undefined;
         }
+        return !!address
     }
 
     get lastStatus() {


### PR DESCRIPTION
WebWallet strategy logout was working only with second attempt.

The reason behind it was because the `?address=WALLET_ADDRESS` URL parameter was present when the logout button was clicked. Because of that, right after the first logout click, the wallet address was being reset in the localStorage. It was working with the second attempt because that parameter in the URL was not present anymore.

What the fix does, it's removing the URL parameter(s) with `window.history.pushState({}, document.title, window.location.pathname);` right after there was a successful wallet authentication.